### PR TITLE
Connect preproc runner

### DIFF
--- a/preprocessor/preproc_runner.sh
+++ b/preprocessor/preproc_runner.sh
@@ -4,8 +4,22 @@
 # The optional second argument is the customer identifier (whatever it is) used to uniquely
 # identify the archive for that customer
 
+function abspath() {
+    if [ -d "$1" ]; then
+        (cd "$1"; pwd)
+    elif [ -f "$1" ]; then
+        if [[ $1 == */* ]]; then
+            echo "$(cd "${1%/*}"; pwd)/${1##*/}"
+        else
+            echo "$(pwd)/$1"
+        fi
+    fi
+}
+
 scriptname=$0
-scriptsdir="`dirname \"$0\"`"
+relscriptsdir="`dirname \"$0\"`"
+scriptsdir=`abspath $relscriptsdir`
+preproc="slack_parser.sh"
 archive_in=`echo "$1" | tr " " "_"`
 cust_id=$2
 mode=$3
@@ -43,17 +57,6 @@ else
   fi
 fi
 
-function abspath() {
-    if [ -d "$1" ]; then
-        (cd "$1"; pwd)
-    elif [ -f "$1" ]; then
-        if [[ $1 == */* ]]; then
-            echo "$(cd "${1%/*}"; pwd)/${1##*/}"
-        else
-            echo "$(pwd)/$1"
-        fi
-    fi
-}
 archive_file=$(abspath ${archive_in})
 
 # check if we can actually have a customer directory to receive decompressed
@@ -74,6 +77,8 @@ then
   then
     echo "ERROR: unable to create a directory for $cust_id"
     exit 7
+  else
+    cust_dir="`pwd`/$cust_id"
   fi
 fi
 
@@ -123,7 +128,6 @@ isbzip(){
 }
 
 load_if_valid_archive(){
-  echo "test"
   if iszip || isgzip || isbzip
   then
     load_customer
@@ -137,7 +141,7 @@ load_if_valid_archive(){
 # could take a while to fail for, say, a truncated archive, or running out of
 # disk space.
 load_customer(){
-  cd $cust_id
+  cd $cust_dir
   if iszip
   then
     unzip $archive_file
@@ -154,5 +158,52 @@ load_customer(){
     exit 10
   fi
 }
-load_if_valid_archive
-#TODO: execute preproc
+
+# finds and cleans all the source dirs. By default, zip uploads will only
+# contain one slack archive, but this function means that they can upload
+# archive files containing multiple slack archives and we can handle them all.
+# The archives can't be nested, however; they should be siblings
+arch_paths=() # creating as global variable for set_source_dirs() to set
+set_source_dirs(){
+  OIFS=$IFS
+  IFS=$'\n'
+  # arch_paths[0] holds the holds the final array index
+  arch_paths=( `find $(pwd) -name "users.json" |awk '{ent= ent "\n" substr($0,1,(length($0) - 10))} END {print NR "\n" ent}'` )
+  IFS=$OIFS
+  # cycle through and clean up any directories with spaces, which can cause
+  # problems for other tools/utilities/whatever.
+  for i in `seq 1 ${arch_paths[0]}`
+  do
+    startpath=${arch_paths[${i}]}
+    cleanpath=`echo "$startpath" | tr " " "_"`
+    if [ "$startpath " != "$cleanpath " ]
+    then # need to clean up spaces
+      mv "$startpath" $cleanpath
+      if [ $? -ne 0 ]
+      then
+        echo "ERROR: unable to mv customer archive from \"$startpath\" to \"$cleanpath\""
+        exit 12
+      fi
+      arch_paths[${i}]="$cleanpath"
+    fi #if [ "$startpath " != "$cleanpath " ]
+  done #for (i=1; i<=${arch_paths[0]}; i++)
+}
+#MVP script=based parser, to be replaced w/batabase or whatever
+channel_list=""
+run_script_parser(){
+  for i in `seq 1 ${arch_paths[0]}`
+  do
+    find_channels `echo ${arch_paths[${i}]} | awk '{print substr($0,1,(length($0) - 1))}'`
+  done
+  cd $cust_dir # make sure we're in the customer dir, so the 'parsed' dirs ends up where expected.
+  ${scriptsdir}/${preproc} $channel_list
+}
+find_channels(){
+  channel_list="$channel_list `find $1 -type d`"
+}
+
+
+#TODO: check for space handling with alternate formats
+load_if_valid_archive # always do
+set_source_dirs #always do
+run_script_parser #will change w/backend

--- a/preprocessor/slack_parser.sh
+++ b/preprocessor/slack_parser.sh
@@ -37,7 +37,7 @@ interleave_days(){
     do
       for day in $(seq -w 01 31)
       do
-        files=`find $outdir -name "${year}-${month}-${day}.*.csv"`
+        files=`find $outdir -name "${year}-${month}-${day}:*.csv"`
         if [ "$files " != " " ]; then
           cat $files |sort > ${outdir}/${year}-${month}-${day}.csv
         fi
@@ -53,8 +53,9 @@ do
     for dayfile in `ls $indir/*.json`
     do
       dayfile=`basename $dayfile`
-      echo "" > $outdir/${dayfile%.json}.$indir.csv #clear out anything that's there w/o needing to delete
-      grep -A 4 "\"type\": \"message\"," $indir/$dayfile | awk -v src_chan=$indir '$1=="\"user\":" {split($2,a,"\""); user=a[2]}$1=="\"text\":" {split($0,a,": "); text=a[2]; sub(/,$/,"",text)}$1=="\"ts\":" {split($2,a,"\""); timestamp=a[2]; print timestamp","user","src_chan","text}' >> $outdir/${dayfile%.json}.$indir.csv
+      channel_name=`echo $indir | awk '{dirdepth=split($0,a,"/"); print a[dirdepth-1]":"a[dirdepth]}'`
+      echo "" > $outdir/${dayfile%.json}:$channel_name.csv #clear out anything that's there w/o needing to delete
+      grep -A 4 "\"type\": \"message\"," $indir/$dayfile | awk -v src_chan=$channel_name '$1=="\"user\":" {split($2,a,"\""); user=a[2]}$1=="\"text\":" {split($0,a,": "); text=a[2]; sub(/,$/,"",text)}$1=="\"ts\":" {split($2,a,"\""); timestamp=a[2]; print timestamp","user","src_chan","text}' >> $outdir/${dayfile%.json}:$channel_name.csv
     done
   else
     echo "$indir is not a readable directory;skipping"


### PR DESCRIPTION
closes #7 

(very slightly) Expanded API:
`./preproc_runner.sh archive_filename customer_id [debug|silent]`
The preproc_runner must be run from the same directory as the archive_filename.
The archive_filename must be just the base filename, with no path in it
The customer_id can be any combinations of alphanumeric, dashes, underscores and periods.
The last argument debug or silent are optional. if set to debug, then the called receives STDERR and STDOUT as normal. If not specified, then the script's internal error messages are sent to STDERR, but the STDERR from tools such as the decompressor will be suppressed* If set to silent, then no output is sent to either. Note that every script internal error also has its own return code, 1-12, so you can understand errors without reading the associated text string.

1 no archive specified
2 invalid characters in filename:$archive_in
3 the archive filename given is not a file
4 the archive file is not readable
5 no customer specified
6 invalid characters in the customer id
7 unable to create a directory for the customer
8 preexisting customer directory is not writable
9 the archive file does not look like a valid archive. (not a tarball or zip file)
10 unable to decompress the archive file to the customer directory
11 cannot rename a an archive filename containing spaces to its equivalent using underscores
12 cannot rename a slack archive from its name with spaces to its equivalent using underscores

1-9 and 11 would be basically instant errors, but 10 and 12 could take longer as they happen during or after decompression.