### PR TITLE
implement date range search

### DIFF
--- a/preprocessor/slack_parser.sh
+++ b/preprocessor/slack_parser.sh
@@ -79,7 +79,7 @@ do
     do
       dayfile=`basename $dayfile`
       channel_name=`echo $indir | awk '{dirdepth=split($0,a,"/"); print a[dirdepth-1]":"a[dirdepth]}'`
-      echo "" > $outdir/${dayfile%.json}:$channel_name.csv #clear out anything that's there w/o needing to delete
+      printf "" > $outdir/${dayfile%.json}:$channel_name.csv #clear out anything that's there w/o needing to delete
       grep -A 4 "\"type\": \"message\"," $indir/$dayfile |sed "${seds}" | awk -v src_chan=$channel_name '$1=="\"user\":" {split($2,a,"\""); user=a[2]}$1=="\"text\":" {split($0,a,": "); text=a[2]; sub(/,$/,"",text)}$1=="\"ts\":" {split($2,a,"\""); timestamp=a[2]; print timestamp","user","src_chan","text}' >> $outdir/${dayfile%.json}:$channel_name.csv
     done
   else


### PR DESCRIPTION
Implements date range searches. Currently only goes down to 'day' resolution, but could easily be pushed to minute or second resolution.

The date ranges are as described in the code. To clarify,
- '2017-02-05:' will search from the beginning of the day February 5th 2017 to present.
- ':2017-02-30' will search from 2009 (the beginning of Slack) to the end of the day on February 30th 2017.
- '2017-02-05:2017-02-30' will search from February 5th 2017 to February 30th 2017.

Also fixes two unreported bugs:
- the source filename being at the beginning of the record
- extra blank lines at the beginning of parsed transcripts